### PR TITLE
 fixed broken image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -48,7 +48,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={'/placeholder.png'}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
![image](https://user-images.githubusercontent.com/89484481/182666365-c04a1f77-1563-4c35-8eff-e2da93a16804.png)
previews placeholder.png when  creating a new product without an image